### PR TITLE
Data fetching with Tanstack Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.6",
+    "@tanstack/react-query": "^5.76.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwindcss": "^4.1.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.6
         version: 4.1.6(vite@6.3.5(jiti@2.4.2)(lightningcss@1.29.2))
+      '@tanstack/react-query':
+        specifier: ^5.76.1
+        version: 5.76.1(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -571,6 +574,14 @@ packages:
     resolution: {integrity: sha512-zjtqjDeY1w3g2beYQtrMAf51n5G7o+UwmyOjtsDMP7t6XyoRMOidcoKP32ps7AkNOHIXEOK0bhIC05dj8oJp4w==}
     peerDependencies:
       vite: ^5.2.0 || ^6
+
+  '@tanstack/query-core@5.76.0':
+    resolution: {integrity: sha512-FN375hb8ctzfNAlex5gHI6+WDXTNpe0nbxp/d2YJtnP+IBM6OUm7zcaoCW6T63BawGOYZBbKC0iPvr41TteNVg==}
+
+  '@tanstack/react-query@5.76.1':
+    resolution: {integrity: sha512-YxdLZVGN4QkT5YT1HKZQWiIlcgauIXEIsMOTSjvyD5wLYK8YVvKZUPAysMqossFJJfDpJW3pFn7WNZuPOqq+fw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
@@ -1877,6 +1888,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.6
       tailwindcss: 4.1.6
       vite: 6.3.5(jiti@2.4.2)(lightningcss@1.29.2)
+
+  '@tanstack/query-core@5.76.0': {}
+
+  '@tanstack/react-query@5.76.1(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.76.0
+      react: 19.1.0
 
   '@types/estree@1.0.7': {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,11 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Deck } from "./components/Deck";
+
+const queryClient = new QueryClient();
+
 function App() {
   return (
-    <>
+    <QueryClientProvider client={queryClient}>
       <header>
         <div>
           <h1>Memory Card</h1>
@@ -14,8 +19,10 @@ function App() {
           <p>Best Score</p>
         </div>
       </header>
-      <main></main>
-    </>
+      <main>
+        <Deck />
+      </main>
+    </QueryClientProvider>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,12 +23,14 @@ function Header() {
 
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
+    <>
       <Header />
-      <main>
-        <Deck />
-      </main>
-    </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <main>
+          <Deck />
+        </main>
+      </QueryClientProvider>
+    </>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,22 +3,28 @@ import { Deck } from "./components/Deck";
 
 const queryClient = new QueryClient();
 
+function Header() {
+  return (
+    <header>
+      <div>
+        <h1>Memory Card</h1>
+        <p>
+          Get points by clicking an image, but be sure to not click more than
+          once!
+        </p>
+      </div>
+      <div>
+        <p>Score</p>
+        <p>Best Score</p>
+      </div>
+    </header>
+  );
+}
+
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <header>
-        <div>
-          <h1>Memory Card</h1>
-          <p>
-            Get points by clicking an image, but be sure to not click more than
-            once!
-          </p>
-        </div>
-        <div>
-          <p>Score</p>
-          <p>Best Score</p>
-        </div>
-      </header>
+      <Header />
       <main>
         <Deck />
       </main>

--- a/src/components/Deck.tsx
+++ b/src/components/Deck.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { type ICard, Card } from "./Card";
 
 interface IDeck {
@@ -7,13 +8,32 @@ interface IDeck {
   remaining: number;
 }
 
-export function Deck(props: { deck: IDeck }) {
+export function Deck() {
+  const { isPending, error, data, isFetching } = useQuery({
+    queryKey: ["deck"],
+    queryFn: async (): Promise<IDeck> => {
+      const response = await fetch(
+        "https://www.deckofcardsapi.com/api/deck/new/draw/?count=10"
+      );
+
+      return await response.json();
+    },
+  });
+
+  if (isPending) {
+    return <p>Loading...</p>;
+  }
+
+  if (error) {
+    return <p>An error has occured: {error.message}</p>;
+  }
+
   return (
     <>
-      {props.deck.success &&
-        props.deck.cards.map((card) => {
-          <Card key={card.code} card={card} />;
-        })}
+      {data.success &&
+        data.cards.map((card) => <Card key={card.code} card={card} />)}
+
+      <div>{isFetching ? "Updating..." : ""}</div>
     </>
   );
 }


### PR DESCRIPTION
Use tanstack query to fetch a deck of cards from the deck of cards API, and then render
this deck of cards as a set of components nested in the <main> element

- **build: install @tanstack/react-query via pnpm**
- **feat: use tanstack-query to fetch and render deck of cards**
- **feat: wrap the App component body in a QueryClientProvider**
- **refactor: create a Header component from the header element**
- **refactor: wrap only the main element in a QueryClientProvider**
